### PR TITLE
fix: avoid initializing sighash celldep from genesis in tests

### DIFF
--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -88,8 +88,6 @@ pub mod rpc_client;
 #[cfg(test)]
 pub use mock_rpc_client as rpc_client;
 
-use sighash::init_sighash_celldep;
-
 #[cfg(test)]
 mod tests;
 
@@ -366,15 +364,16 @@ impl ChainEndpoint for CkbChain {
         let rpc_client = Arc::new(RpcClient::new(&config.ckb_rpc, &config.ckb_indexer_rpc));
         let storage = Storage::new(&config.data_dir)?;
 
-        rt.block_on(init_sighash_celldep(rpc_client.as_ref()))?;
-
-        // check contract and lock type_id_args wether are on-chain deployed
         #[cfg(not(test))]
         {
             use ckb_sdk::constants::TYPE_ID_CODE_HASH;
             use ckb_types::prelude::Pack;
             use prelude::CellSearcher;
+            use sighash::init_sighash_celldep;
 
+            rt.block_on(init_sighash_celldep(rpc_client.as_ref()))?;
+
+            // check if contract and lock type_id_args are on-chain deployed
             let contract_cell = rt.block_on(rpc_client.search_cell_by_typescript(
                 &TYPE_ID_CODE_HASH.pack(),
                 &config.lightclient_contract_typeargs.as_bytes().to_owned(),

--- a/crates/relayer/src/chain/ckb/helper.rs
+++ b/crates/relayer/src/chain/ckb/helper.rs
@@ -141,7 +141,7 @@ pub trait TxCompleter: CellSearcher {
             .as_advanced_builder()
             .output(change_cell)
             .output_data(Bytes::new().pack())
-            .cell_dep(get_secp256k1_celldep().clone())
+            .cell_dep(get_secp256k1_celldep(address.network()))
             .build();
         Ok((tx, inputs_cell_as_output))
     }

--- a/crates/relayer/src/chain/ckb/sighash.rs
+++ b/crates/relayer/src/chain/ckb/sighash.rs
@@ -1,52 +1,122 @@
 // Reference implementation:
 // https://github.com/cryptape/kabletop-ckb-sdk/blob/master/src/ckb/transaction/genesis.rs
 
-use super::prelude::CkbReader;
-use crate::error::Error;
-use ckb_jsonrpc_types::TransactionView;
-use ckb_types::{
-    core::DepType,
-    packed::{CellDep, OutPoint},
-    prelude::*,
-};
-use tokio::sync::OnceCell;
+#[cfg(not(test))]
+mod no_test {
+    use super::super::prelude::CkbReader;
+    use crate::error::Error;
+    use ckb_jsonrpc_types::TransactionView;
+    use ckb_sdk::NetworkType;
+    use ckb_types::{
+        core::DepType,
+        packed::{CellDep, OutPoint},
+        prelude::*,
+    };
+    use tokio::sync::OnceCell;
 
-const SIGHASH_GROUP_OUTPUT: (usize, usize) = (1, 0);
+    const SIGHASH_GROUP_OUTPUT: (usize, usize) = (1, 0);
 
-pub static SIGHASH_CELLDEP: OnceCell<CellDep> = OnceCell::const_new();
+    static SIGHASH_CELLDEP: OnceCell<CellDep> = OnceCell::const_new();
 
-pub fn get_secp256k1_celldep() -> &'static CellDep {
-    SIGHASH_CELLDEP
-        .get()
-        .expect("uninitialized sighash celldep")
+    pub fn get_secp256k1_celldep(_network_type: NetworkType) -> CellDep {
+        SIGHASH_CELLDEP
+            .get()
+            .expect("uninitialized sighash celldep")
+            .clone()
+    }
+
+    pub async fn init_sighash_celldep(
+        rpc_client: &impl CkbReader,
+    ) -> Result<&'static CellDep, Error> {
+        SIGHASH_CELLDEP
+            .get_or_try_init(|| async {
+                let block = rpc_client
+                    .get_block_by_number(0.into())
+                    .await
+                    .map_err(|e| {
+                        Error::rpc_response(format!("failed to get genesis block: {e}"))
+                    })?;
+                let sighash_group_tx = block
+                    .transactions
+                    .get(SIGHASH_GROUP_OUTPUT.0)
+                    .expect("no sighash group transaction found in genesis");
+
+                let celldep = build_celldep(sighash_group_tx, SIGHASH_GROUP_OUTPUT.1 as u32);
+                tracing::info!("sighash celldep is initialized to: {celldep}");
+                Ok(celldep)
+            })
+            .await
+    }
+
+    fn build_celldep(tx: &TransactionView, tx_index: u32) -> CellDep {
+        let outpoint = OutPoint::new_builder()
+            .tx_hash(tx.hash.pack())
+            .index(tx_index.pack())
+            .build();
+        CellDep::new_builder()
+            .out_point(outpoint)
+            .dep_type(DepType::DepGroup.into())
+            .build()
+    }
 }
 
-pub async fn init_sighash_celldep(rpc_client: &impl CkbReader) -> Result<&'static CellDep, Error> {
-    SIGHASH_CELLDEP
-        .get_or_try_init(|| async {
-            let block = rpc_client
-                .get_block_by_number(0.into())
-                .await
-                .map_err(|e| Error::rpc_response(format!("failed to get genesis block: {e}")))?;
-            let sighash_group_tx = block
-                .transactions
-                .get(SIGHASH_GROUP_OUTPUT.0)
-                .expect("no sighash group transaction found in genesis");
+#[cfg(test)]
+mod test {
+    use ckb_sdk::NetworkType;
+    use ckb_types::{
+        core::DepType,
+        h256,
+        packed::{CellDep, OutPoint},
+        prelude::*,
+    };
 
-            let celldep = build_celldep(sighash_group_tx, SIGHASH_GROUP_OUTPUT.1 as u32);
-            tracing::info!("sighash celldep is initialized to: {celldep}");
-            Ok(celldep)
-        })
-        .await
+    pub fn get_secp256k1_celldep(network_type: NetworkType) -> CellDep {
+        let celldep = CellDep::new_builder()
+            .dep_type(DepType::DepGroup.into())
+            .build();
+        match network_type {
+            NetworkType::Mainnet => celldep
+                .as_builder()
+                .out_point(
+                    OutPoint::new_builder()
+                        .tx_hash(
+                            h256!("0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c")
+                                .pack(),
+                        )
+                        .index(0u32.pack())
+                        .build(),
+                )
+                .build(),
+            NetworkType::Testnet => celldep
+                .as_builder()
+                .out_point(
+                    OutPoint::new_builder()
+                        .tx_hash(
+                            h256!("0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37")
+                                .pack(),
+                        )
+                        .index(0u32.pack())
+                        .build(),
+                )
+                .build(),
+            NetworkType::Dev => celldep
+                .as_builder()
+                .out_point(
+                    OutPoint::new_builder()
+                        .tx_hash(
+                            h256!("0x29ed5663501cd171513155f8939ad2c9ffeb92aa4879d39cde987f8eb6274407")
+                                .pack(),
+                        )
+                        .index(0u32.pack())
+                        .build(),
+                )
+                .build(),
+            _ => celldep,
+        }
+    }
 }
 
-fn build_celldep(tx: &TransactionView, tx_index: u32) -> CellDep {
-    let outpoint = OutPoint::new_builder()
-        .tx_hash(tx.hash.pack())
-        .index(tx_index.pack())
-        .build();
-    CellDep::new_builder()
-        .out_point(outpoint)
-        .dep_type(DepType::DepGroup.into())
-        .build()
-}
+#[cfg(not(test))]
+pub use no_test::*;
+#[cfg(test)]
+pub use test::*;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #220 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->
- Avoid initializing sighash celldep from genesis in tests.
- Use `mod no_test` and `mod test` to separate those code to avoid unused item warnings in CI.
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Forcerelay) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
